### PR TITLE
merge basic partitioning support (WIP)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-# only build changes tagged previously by AppVeyor build
-if: tag IS present
+# only build changes tagged previously by AppVeyor build and pull requests
+if: tag IS present OR type = pull_request
 
 language: csharp
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ What frameworks are targeted, with rationale:
 
 - Microsoft.AspNetCore.Identity - supports net451 and netstandard1.3
 - Microsoft.Azure.DocumentDB v1.10.0 - supports net45
-- Microsoft.Azure.DocumentDB.Core v1.0.0 - supports netstandard1.6
+- Microsoft.Azure.DocumentDB v1.21.0 - supports netstandard1.6
 - Thus, the lowest common denominators are net451 and netstandard1.6
+
+For support for the now deprecated `Microsoft.Azure.DocumentDB.Core` package you can still use v1.0.0.
 
 Additionally this projects targets netstandard2.0 explicitly due to its incompaibility with older versions of Microsoft.AspNetCore.Identity.
 For netstandard2.0 Microsoft.AspNetCore.Identity v2.0 is required.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@
   configuration:
   - Release
   image: Visual Studio 2017
-  platform: Any CPU
+  platform: x64
   environment:
     # Don't report back to the mothership
     DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@
   - ps: $NewBuildVersion = "${DotnetVersionPrefix}" + "$VersionSuffix"
   - ps: Update-AppveyorBuild -Version $NewBuildVersion
   # Install DocumentDB Emulator
-  - ps: Start-FileDownload 'https://aka.ms/documentdb-emulator' -FileName 'C:\DocumentDB.Emulator.msi'
+  - ps: Start-FileDownload 'https://aka.ms/cosmosdb-emulator' -FileName 'C:\DocumentDB.Emulator.msi'
   - msiexec.exe /i C:\DocumentDB.Emulator.msi /quiet /qn /log install.log
   - ps: >-
       & "${env:ProgramFiles}\DocumentDB Emulator\DocumentDB.Emulator.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@
   # https://www.appveyor.com/docs/branches/#build-on-tags-github-gitlab-and-bitbucket-only
   skip_tags: true
   # version will be overwritten during install step
-  version: '1.0.{build}'
+  version: '1.1.{build}'
   configuration:
   - Release
   image: Visual Studio 2017

--- a/samples/AspNetCore.Identity.DocumentDB.Sample/Startup.cs
+++ b/samples/AspNetCore.Identity.DocumentDB.Sample/Startup.cs
@@ -47,15 +47,13 @@ namespace AspNetCore.Identity.DocumentDB.Sample
             // make sure the database exists!
             Database db = client.CreateDatabaseQuery().Where(d => d.Id == databaseId).AsEnumerable().FirstOrDefault()
                 ?? client.CreateDatabaseAsync(new Database { Id = databaseId }).Result;
-            
-            var databaseLink = db.SelfLink;
 
             // add Identity Server with DocumentDB stores (will store data in collections "users" and "roles")
             // services.AddIdentityWithDocumentDBStoresUsingCustomTypes<MyUser, MyRole>(client, databaseLink);
 
             // variant 2:
             services.AddIdentity<MyUser, MyRole>()
-                .RegisterDocumentDBStores<MyUser, MyRole>(client, databaseLink);
+                .RegisterDocumentDBStores<MyUser, MyRole>(client, (p) => new DocumentCollection { Id = "userCollection" });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
+++ b/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A DocumentDB (Cosmos DB) provider for ASP.NET Core Identity framework.</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>2.0.0-beta</VersionPrefix>
     <Authors>Felix Schröter</Authors>
     <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
     <WarningsAsErrors>true</WarningsAsErrors>

--- a/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
+++ b/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>AspNetCore.Identity.DocumentDB</AssemblyName>
     <PackageId>AspNetCore.Identity.DocumentDB</PackageId>
     <PackageTags>AspNetCore;Azure;CosmosDB;DocumentDB;identity;membership</PackageTags>
-    <PackageReleaseNotes>- added support for Microsoft.Azure.DocumentDB 1.21.0 (which now supports both .NET Framework and .NET Core)
+    <PackageReleaseNotes>- added support for Microsoft.Azure.DocumentDB 1.21.0 (which now supports both .NET Framework and .NET Standard)
 - removed support for now deprecated Microsoft.Azure.DocumentDB.Core package (you can still use v1.0.0 if you need it)
     </PackageReleaseNotes>
     <PackageIconUrl>https://raw.githubusercontent.com/FelschR/AspNetCore.Identity.DocumentDB/netcore/imgs/icon.png</PackageIconUrl>

--- a/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
+++ b/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
@@ -9,8 +9,15 @@
     <AssemblyName>AspNetCore.Identity.DocumentDB</AssemblyName>
     <PackageId>AspNetCore.Identity.DocumentDB</PackageId>
     <PackageTags>AspNetCore;Azure;CosmosDB;DocumentDB;identity;membership</PackageTags>
-    <PackageReleaseNotes>- added support for Microsoft.Azure.DocumentDB 1.21.0 (which now supports both .NET Framework and .NET Standard)
-- removed support for now deprecated Microsoft.Azure.DocumentDB.Core package (you can still use v1.0.0 if you need it)
+    <PackageReleaseNotes>
+        This is the first iteration of the partitioning support.
+        There are still issues e.g. with setting and querying Logins but the basic functionalities of User and Role stores should work.
+
+        There were some other refactorings and changes like all JSON properties are now camelCase.
+        Thus it is not compatible with datasets of older library versions.
+
+        Currently the library only supports "/partition" as the JSON field for the partition key.
+        There is a configuration variable for it but setting it to something other than "/partition" will fail.
     </PackageReleaseNotes>
     <PackageIconUrl>https://raw.githubusercontent.com/FelschR/AspNetCore.Identity.DocumentDB/netcore/imgs/icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/FelschR/AspNetCore.Identity.DocumentDB</PackageProjectUrl>

--- a/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
+++ b/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
@@ -29,10 +29,6 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.0.0" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
@@ -40,7 +36,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'netstandard1.6' ">
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
+++ b/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
@@ -2,17 +2,15 @@
 
   <PropertyGroup>
     <Description>A DocumentDB (Cosmos DB) provider for ASP.NET Core Identity framework.</Description>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <Authors>Felix Schröter</Authors>
     <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
     <WarningsAsErrors>true</WarningsAsErrors>
     <AssemblyName>AspNetCore.Identity.DocumentDB</AssemblyName>
     <PackageId>AspNetCore.Identity.DocumentDB</PackageId>
     <PackageTags>AspNetCore;Azure;CosmosDB;DocumentDB;identity;membership</PackageTags>
-    <PackageReleaseNotes>this is the first officially stable release!
-- updated readme with proper documentation
-- added sample project for aspnetcore1.0 and aspnetcore2.0
-- AddIdentityWithDocumentDBStoresUsingCustomTypes is now deprecated
+    <PackageReleaseNotes>- added support for Microsoft.Azure.DocumentDB 1.21.0 (which now supports both .NET Framework and .NET Core)
+- removed support for now deprecated Microsoft.Azure.DocumentDB.Core package (you can still use v1.0.0 if you need it)
     </PackageReleaseNotes>
     <PackageIconUrl>https://raw.githubusercontent.com/FelschR/AspNetCore.Identity.DocumentDB/netcore/imgs/icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/FelschR/AspNetCore.Identity.DocumentDB</PackageProjectUrl>
@@ -29,18 +27,17 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.10.0" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.10.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.21.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/AspNetCore.Identity.DocumentDB/DocumentDBIdentityBuilderExtensions.cs
+++ b/src/AspNetCore.Identity.DocumentDB/DocumentDBIdentityBuilderExtensions.cs
@@ -17,28 +17,81 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class DocumentDBIdentityBuilderExtensions
     {
         /// <summary>
+        ///     If you want control over creating the users and roles collections, use this overload.
         ///     This method only registers DocumentDB stores, you also need to call AddIdentity.
-        ///     Consider using AddIdentityWithDocumentDBStores.
         /// </summary>
         /// <param name="builder"></param>
-        /// <param name="documentClient">Must be an initialized DocumentClient</param>
-        /// <param name="databaseLink">Must contain the database link</param>
-        public static IdentityBuilder RegisterDocumentDBStores<TUser, TRole>(this IdentityBuilder builder, DocumentClient documentClient, string databaseLink)
+        /// <param name="documentClient"></param>
+        /// <param name="collectionFactory">Function containing DocumentCollection</param>
+        public static IdentityBuilder RegisterDocumentDBStores(
+            this IdentityBuilder builder,
+            Action<DocumentDbOptions> documentDbOptions)
+        {
+            return RegisterDocumentDBStores<IdentityUser, IdentityRole>(builder, documentDbOptions);
+        }
+
+        /// <summary>
+        ///     If you want control over creating the users and roles collections, use this overload.
+        ///     This method only registers DocumentDB stores, you also need to call AddIdentity.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="documentClient"></param>
+        /// <param name="collectionFactory">Function containing DocumentCollection</param>
+        public static IdentityBuilder RegisterDocumentDBStores<TUser, TRole>(
+            this IdentityBuilder builder,
+            Action<DocumentDbOptions> documentDbOptions)
             where TRole : IdentityRole
             where TUser : IdentityUser
         {
-            if (documentClient == null)
+            var dbOptions = new DocumentDbOptions();
+            documentDbOptions(dbOptions);
+
+            if (dbOptions == null)
             {
-                throw new ArgumentException("documentClient cannot be null");
+                throw new ArgumentException("dbOptions cannot be null.");
+            }
+            if (dbOptions.DocumentUrl == null)
+            {
+                throw new ArgumentException("DocumentUrl cannot be null.");
+            }
+            if (dbOptions.DocumentKey == null)
+            {
+                throw new ArgumentException("DocumentKey cannot be null.");
+            }
+            if (dbOptions.DatabaseId == null)
+            {
+                throw new ArgumentException("DatabaseId cannot be null.");
+            }
+            if (dbOptions.CollectionId == null)
+            {
+                throw new ArgumentException("CollectionId cannot be null.");
             }
 
-            var collectionId = databaseLink.Substring(4);
-            documentClient.CreateDatabaseIfNotExistsAsync(collectionId).Wait(30 * 1000); //30 seconds
+            var documentClient = new DocumentClient(new Uri(dbOptions.DocumentUrl), dbOptions.DocumentKey, dbOptions.ConnectionPolicy);
+            var database = documentClient.CreateDatabaseIfNotExistsAsync(dbOptions.DatabaseId).Result;
+            var collection = new DocumentCollection { Id = dbOptions.CollectionId };
+            if (dbOptions.PartitionKeyDefinition != null)
+            {
+                collection.PartitionKey = dbOptions.PartitionKeyDefinition;
+            }
+            collection = documentClient.CreateDocumentCollectionIfNotExistsAsync(dbOptions.DatabaseId, collection).Result;
 
-            return builder.RegisterDocumentDBStores<TUser, TRole>(
-                documentClient,
-                p => documentClient.CreateDocumentCollectionQuery(databaseLink).Where(c => c.Id.Equals("users")).AsEnumerable().FirstOrDefault()
-                        ?? documentClient.CreateDocumentCollectionAsync(databaseLink, new DocumentCollection { Id = "users" }).Result);
+            return RegisterDocumentDBStores<TUser, TRole>(builder, documentClient, (p) => collection);
+        }
+
+        /// <summary>
+        ///     If you want control over creating the users and roles collections, use this overload.
+        ///     This method only registers DocumentDB stores, you also need to call AddIdentity.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="documentClient"></param>
+        /// <param name="collectionFactory">Function containing DocumentCollection</param>
+        public static IdentityBuilder RegisterDocumentDBStores(
+            this IdentityBuilder builder,
+            DocumentClient documentClient,
+            Func<IServiceProvider, DocumentCollection> collectionFactory)
+        {
+            return RegisterDocumentDBStores<IdentityUser, IdentityRole>(builder, documentClient, collectionFactory);
         }
 
         /// <summary>
@@ -50,7 +103,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder"></param>
         /// <param name="documentClient"></param>
         /// <param name="collectionFactory">Function containing DocumentCollection</param>
-        public static IdentityBuilder RegisterDocumentDBStores<TUser, TRole>(this IdentityBuilder builder,
+        public static IdentityBuilder RegisterDocumentDBStores<TUser, TRole>(
+            this IdentityBuilder builder,
             DocumentClient documentClient,
             Func<IServiceProvider, DocumentCollection> collectionFactory)
             where TRole : IdentityRole
@@ -78,32 +132,6 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        ///     This method only registers DocumentDB stores, you also need to call AddIdentity.
-        ///     Consider using AddIdentityWithDocumentDBStores.
-        /// </summary>
-        /// <typeparam name="TUser">The type associated with user identity information.</typeparam>
-        /// <typeparam name="TRole">The type associated with role identity information.</typeparam>
-        /// <param name="builder">The <see cref="IdentityBuilder"/> to build upon.</param>
-        /// <param name="options">The options for creating the DocumentDB client.</param>
-        /// <returns>The <see cref="IdentityBuilder"/> with the DocumentDB settings applied.</returns>
-        /// <remarks>
-        ///     This does <b>not</b> register the options with the ASP.Net Core options framework.
-        /// </remarks>
-        public static IdentityBuilder RegisterDocumentDBStores<TUser, TRole>(
-            this IdentityBuilder builder,
-            Action<DocumentDbOptions> options)
-            where TRole : IdentityRole
-            where TUser : IdentityUser
-        {
-            var dbOptions = new DocumentDbOptions();
-            options(dbOptions);
-
-            var client = new DocumentClient(new Uri(dbOptions.DocumentUrl), dbOptions.DocumentKey, dbOptions.ConnectionPolicy);
-
-            return builder.RegisterDocumentDBStores<TUser, TRole>(client, UriFactory.CreateDatabaseUri(dbOptions.CollectionId).ToString());
-        }
-
-        /// <summary>
         ///     This method registers identity services and DocumentDB stores using the IdentityUser and IdentityRole types.
         /// </summary>
         /// <param name="service">The <see cref="IdentityBuilder"/> to build upon.</param>
@@ -116,8 +144,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Action<IdentityOptions> identityOptions = null)
         {
             return service.AddIdentityWithDocumentDBStores<IdentityUser, IdentityRole>(
-                    documentDbOptions, identityOptions)
-                ;
+                    documentDbOptions, identityOptions);
         }
 
         /// <summary>
@@ -142,50 +169,61 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        ///     This method registers identity services and DocumentDB stores using the IdentityUser and IdentityRole types.
-        /// </summary>
-        /// <param name="services"></param>
-        /// <param name="documentClient">Must be an initialized DocumentClient</param>
-        /// <param name="databaseLink">Must contain the database link</param>
-        /// <param name="identityOptions">The identity options used when calling AddIdentity.</param>
-        public static IdentityBuilder AddIdentityWithDocumentDBStores(this IServiceCollection services, DocumentClient documentClient, string databaseLink,
-            Action<IdentityOptions> identityOptions = null)
-        {
-            return services.AddIdentityWithDocumentDBStores<IdentityUser, IdentityRole>(documentClient, databaseLink, identityOptions);
-        }
-
-        /// <summary>
         ///     This method allows you to customize the user and role type when registering identity services
-        ///     and DocumentDB stores.
+        ///     and DocumentDB stores.`
         /// </summary>
-        /// <typeparam name="TUser"></typeparam>
-        /// <typeparam name="TRole"></typeparam>
-        /// <param name="services"></param>
-        /// <param name="documentClient">Must be an initialized DocumentClient</param>
-        /// <param name="databaseLink">Must contain the database link</param>
+        /// <typeparam name="TUser">The type associated with user identity information.</typeparam>
+        /// <typeparam name="TRole">The type associated with role identity information.</typeparam>
+        /// <param name="service">The <see cref="IdentityBuilder"/> to build upon.</param>
+        /// <param name="documentDbOptions">The options for creating the DocumentDB client.</param>
         /// <param name="identityOptions">The identity options used when calling AddIdentity.</param>
-        public static IdentityBuilder AddIdentityWithDocumentDBStores<TUser, TRole>(this IServiceCollection services, DocumentClient documentClient, string databaseLink,
+        /// <returns>The <see cref="IdentityBuilder"/> with the DocumentDB settings applied.</returns>
+        public static IdentityBuilder AddIdentityWithDocumentDBStores<TUser, TRole>(
+            this IServiceCollection service,
+            DocumentClient documentClient,
+            Func<IServiceProvider, DocumentCollection> collectionFactory,
             Action<IdentityOptions> identityOptions = null)
             where TUser : IdentityUser
             where TRole : IdentityRole
         {
-            return services.AddIdentity<TUser, TRole>(identityOptions)
-                .RegisterDocumentDBStores<TUser, TRole>(documentClient, databaseLink);
+            return service.AddIdentity<TUser, TRole>(identityOptions)
+                .RegisterDocumentDBStores<TUser, TRole>(documentClient, collectionFactory);
         }
 
-        private static async Task CreateDatabaseIfNotExistsAsync(this IDocumentClient client, string databaseId)
+        private static async Task<Database> CreateDatabaseIfNotExistsAsync(this IDocumentClient client, string databaseId)
         {
+            Database database;
+
             try
             {
-                await client.ReadDatabaseAsync(UriFactory.CreateDatabaseUri(databaseId));
+                database = (await client.ReadDatabaseAsync(UriFactory.CreateDatabaseUri(databaseId))).Resource;
             }
             catch (DocumentClientException ex)
             {
                 if (ex.StatusCode == HttpStatusCode.NotFound)
-                    await client.CreateDatabaseAsync(new Database { Id = databaseId });
+                    database = (await client.CreateDatabaseAsync(new Database { Id = databaseId })).Resource;
                 else
                     throw;
             }
+
+            return database;
+        }
+
+        private static async Task<DocumentCollection> CreateDocumentCollectionIfNotExistsAsync(this IDocumentClient client, string databaseId, DocumentCollection collection)
+        {
+            try
+            {
+                collection = (await client.ReadDocumentCollectionAsync(UriFactory.CreateDocumentCollectionUri(databaseId, collection.Id))).Resource;
+            }
+            catch (DocumentClientException ex)
+            {
+                if (ex.StatusCode == HttpStatusCode.NotFound)
+                    collection = (await client.CreateDocumentCollectionAsync(UriFactory.CreateDatabaseUri(databaseId), collection)).Resource;
+                else
+                    throw;
+            }
+
+            return collection;
         }
     }
 }

--- a/src/AspNetCore.Identity.DocumentDB/DocumentDbOptions.cs
+++ b/src/AspNetCore.Identity.DocumentDB/DocumentDbOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Azure.Documents.Client;
+﻿using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
 
 namespace Microsoft.AspNetCore.Identity.DocumentDB
 {
@@ -11,14 +12,26 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
         /// The URL of the DocumentDB database (Found in Azure).
         /// </summary>
         public string DocumentUrl { get; set; }
+
         /// <summary>
         /// The DocuementDB access key for the database (Found in Azure).
         /// </summary>
         public string DocumentKey { get; set; }
+
+        /// <summary>
+        /// The ID of the database to connect to.
+        /// </summary>
+        public string DatabaseId { get; set; }
+
         /// <summary>
         /// The name of the collection to house identity data.
         /// </summary>
         public string CollectionId { get; set; }
+
+        /// <summary>
+        /// The optional partition key definition.
+        /// </summary>
+        public PartitionKeyDefinition PartitionKeyDefinition { get; set; }
 
         /// <summary>
         /// The <see cref="ConnectionPolicy"/> for the DocumentDB client.

--- a/src/AspNetCore.Identity.DocumentDB/Helper.cs
+++ b/src/AspNetCore.Identity.DocumentDB/Helper.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+
+namespace AspNetCore.Identity.DocumentDB
+{
+    public static class Helper
+    {
+        /// <summary>
+        /// Merges the base request options with the given ones and returns them.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public static RequestOptions GetRequestOptions(object partitionKeyValue, RequestOptions options = null)
+        {
+            if (partitionKeyValue == null)
+            {
+                return options;
+            }
+
+            var partitionKey = new PartitionKey(partitionKeyValue);
+
+            if (options != null)
+            {
+                options.PartitionKey = partitionKey;
+            }
+            else
+            {
+                options = new RequestOptions
+                {
+                    PartitionKey = partitionKey
+                };
+            }
+
+            return options;
+        }
+
+        /// <summary>
+        /// Merges the base feed options with the given ones and returns them.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public static FeedOptions GetFeedOptions(object partitionKeyValue, FeedOptions options = null)
+        {
+            if (partitionKeyValue == null)
+            {
+                return options;
+            }
+
+            var partitionKey = new PartitionKey(partitionKeyValue);
+
+            if (options != null)
+            {
+                options.PartitionKey = partitionKey;
+            }
+            else
+            {
+                options = new FeedOptions
+                {
+                    PartitionKey = partitionKey
+                };
+            }
+
+            return options;
+        }
+    }
+}

--- a/src/AspNetCore.Identity.DocumentDB/IdentityClaim.cs
+++ b/src/AspNetCore.Identity.DocumentDB/IdentityClaim.cs
@@ -21,13 +21,13 @@
         /// <summary>
         /// Claim type
         /// </summary>
-        [JsonProperty(PropertyName = "Type")]
+        [JsonProperty(PropertyName = "type")]
         public string Type { get; set; }
 
         /// <summary>
         /// Claim value
         /// </summary>
-        [JsonProperty(PropertyName = "Value")]
+        [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
 
         public Claim ToSecurityClaim()

--- a/src/AspNetCore.Identity.DocumentDB/IdentityClaimStore.cs
+++ b/src/AspNetCore.Identity.DocumentDB/IdentityClaimStore.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
             Claims = new List<IdentityClaim>();
         }
 
-        [JsonProperty(PropertyName = "Claims", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty(PropertyName = "claims", NullValueHandling = NullValueHandling.Ignore)]
         public virtual List<IdentityClaim> Claims { get; set; }
 
         public virtual void AddClaim(Claim claim)

--- a/src/AspNetCore.Identity.DocumentDB/IdentityRole.cs
+++ b/src/AspNetCore.Identity.DocumentDB/IdentityRole.cs
@@ -14,13 +14,17 @@
             Name = roleName;
         }
 
-        [JsonProperty(PropertyName = "Type")]
+        // TODO make the field name "partition" configurable
+        [JsonProperty("partition")]
+        public virtual string PartitionKey { get { return Id; } }
+
+        [JsonProperty(PropertyName = "type")]
         public virtual TypeEnum Type { get { return TypeEnum.Role; } }
 
-        [JsonProperty(PropertyName = "Name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
-        [JsonProperty(PropertyName = "NormalizedName")]
+        [JsonProperty(PropertyName = "normalizedName")]
         public string NormalizedName { get; set; }
 
         public override string ToString() => Name;

--- a/src/AspNetCore.Identity.DocumentDB/IdentityUser.cs
+++ b/src/AspNetCore.Identity.DocumentDB/IdentityUser.cs
@@ -14,50 +14,54 @@
             Tokens = new List<IdentityUserToken>();
         }
 
-        [JsonProperty(PropertyName = "Type")]
+        // TODO make the field name "partition" configurable
+        [JsonProperty("partition")]
+        public virtual string PartitionKey { get { return Id; } }
+
+        [JsonProperty(PropertyName = "type")]
         public virtual TypeEnum Type { get { return TypeEnum.User; } }
 
-        [JsonProperty(PropertyName = "UserName")]
+        [JsonProperty(PropertyName = "userName")]
         public virtual string UserName { get; set; }
 
-        [JsonProperty(PropertyName = "NormalizedUserName")]
+        [JsonProperty(PropertyName = "normalizedUserName")]
         public virtual string NormalizedUserName { get; set; }
 
         /// <summary>
         ///     A random value that must change whenever a users credentials change
         ///     (password changed, login removed)
         /// </summary>
-        [JsonProperty(PropertyName = "SecurityStamp")]
+        [JsonProperty(PropertyName = "securityStamp")]
         public virtual string SecurityStamp { get; set; }
 
-        [JsonProperty(PropertyName = "Email")]
+        [JsonProperty(PropertyName = "email")]
         public virtual string Email { get; set; }
 
-        [JsonProperty(PropertyName = "NormalizedEmail")]
+        [JsonProperty(PropertyName = "normalizedEmail")]
         public virtual string NormalizedEmail { get; set; }
 
-        [JsonProperty(PropertyName = "EmailConfirmed")]
+        [JsonProperty(PropertyName = "emailConfirmed")]
         public virtual bool EmailConfirmed { get; set; }
 
-        [JsonProperty(PropertyName = "PhoneNumber")]
+        [JsonProperty(PropertyName = "phoneNumber")]
         public virtual string PhoneNumber { get; set; }
 
-        [JsonProperty(PropertyName = "PhoneNumberConfirmed")]
+        [JsonProperty(PropertyName = "phoneNumberConfirmed")]
         public virtual bool PhoneNumberConfirmed { get; set; }
 
-        [JsonProperty(PropertyName = "TwoFactorEnabled")]
+        [JsonProperty(PropertyName = "twoFactorEnabled")]
         public virtual bool TwoFactorEnabled { get; set; }
 
-        [JsonProperty(PropertyName = "LockoutEndDateUtc")]
+        [JsonProperty(PropertyName = "lockoutEndDateUtc")]
         public virtual DateTime? LockoutEndDateUtc { get; set; }
 
-        [JsonProperty(PropertyName = "LockoutEnabled")]
+        [JsonProperty(PropertyName = "lockoutEnabled")]
         public virtual bool LockoutEnabled { get; set; }
 
-        [JsonProperty(PropertyName = "AccessFailedCount")]
+        [JsonProperty(PropertyName = "accessFailedCount")]
         public virtual int AccessFailedCount { get; set; }
 
-        [JsonProperty(PropertyName = "Roles", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty(PropertyName = "roles", NullValueHandling = NullValueHandling.Ignore)]
         public virtual List<string> Roles { get; set; }
 
         public virtual void AddRole(string role)
@@ -70,10 +74,10 @@
             Roles.Remove(role);
         }
 
-        [JsonProperty(PropertyName = "PasswordHash", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty(PropertyName = "passwordHash", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string PasswordHash { get; set; }
 
-        [JsonProperty(PropertyName = "Logins", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty(PropertyName = "logins", NullValueHandling = NullValueHandling.Ignore)]
         public virtual List<IdentityUserLogin> Logins { get; set; }
 
         public virtual void AddLogin(UserLoginInfo login)
@@ -91,7 +95,7 @@
             return false;
         }
         
-        [JsonProperty(PropertyName = "Tokens", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty(PropertyName = "tokens", NullValueHandling = NullValueHandling.Ignore)]
         public virtual List<IdentityUserToken> Tokens { get; set; }
 
         private IdentityUserToken GetToken(string loginProider, string name)

--- a/src/AspNetCore.Identity.DocumentDB/IdentityUserLogin.cs
+++ b/src/AspNetCore.Identity.DocumentDB/IdentityUserLogin.cs
@@ -22,11 +22,11 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
             ProviderKey = login.ProviderKey;
         }
 
-        [JsonProperty(PropertyName = "LoginProvider")]
+        [JsonProperty(PropertyName = "loginProvider")]
         public string LoginProvider { get; set; }
-        [JsonProperty(PropertyName = "ProviderDisplayName")]
+        [JsonProperty(PropertyName = "providerDisplayName")]
         public string ProviderDisplayName { get; set; }
-        [JsonProperty(PropertyName = "ProviderKey")]
+        [JsonProperty(PropertyName = "providerKey")]
         public string ProviderKey { get; set; }
 
         public UserLoginInfo ToUserLoginInfo()

--- a/src/AspNetCore.Identity.DocumentDB/IdentityUserToken.cs
+++ b/src/AspNetCore.Identity.DocumentDB/IdentityUserToken.cs
@@ -14,19 +14,19 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
         /// <summary>
         /// The provider that the token came from.
         /// </summary>
-        [JsonProperty(PropertyName = "LoginProvider")]
+        [JsonProperty(PropertyName = "loginProvider")]
         public string LoginProvider { get; set; }
 
         /// <summary>
         /// The name of the token.
         /// </summary>
-        [JsonProperty(PropertyName = "Name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
         /// The value of the token.
         /// </summary>
-        [JsonProperty(PropertyName = "Value")]
+        [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
     }
 }

--- a/src/AspNetCore.Identity.DocumentDB/PartitionMapping.cs
+++ b/src/AspNetCore.Identity.DocumentDB/PartitionMapping.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Azure.Documents;
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNetCore.Identity.DocumentDB
+{
+    /// <summary>
+    /// A document used to map from another identifier to the partition key.
+    /// In case of IdentityUser it maps from NormalizedUserName to UserId.
+    /// In case of IdentityRole it maps from NormalizedName tod RoleId.
+    /// The Id and PartitionKey are alqays equal here.
+    /// </summary>
+    internal class PartitionMapping : Document
+    {
+        // TODO make configurable
+        [JsonProperty("partition")]
+        public string PartitionKey { get { return Id; } }
+
+        [JsonProperty("type")]
+        public TypeEnum Type { get; set; }
+
+        [JsonProperty("targetId")]
+        public string TargetId { get; set; }
+    }
+}

--- a/src/AspNetCore.Identity.DocumentDB/RoleStore.cs
+++ b/src/AspNetCore.Identity.DocumentDB/RoleStore.cs
@@ -42,7 +42,11 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
 
         public virtual async Task<IdentityResult> CreateAsync(TRole role, CancellationToken token)
         {
-            role.Id = Guid.NewGuid().ToString();
+            if (role.Id == null)
+            {
+                role.Id = Guid.NewGuid().ToString();
+            }
+
             var result = await _Client.CreateDocumentAsync(_Roles.DocumentsLink, role);
             role.Id = result.Resource.Id;
             role.ResourceId = result.Resource.ResourceId;

--- a/src/AspNetCore.Identity.DocumentDB/TypeEnum.cs
+++ b/src/AspNetCore.Identity.DocumentDB/TypeEnum.cs
@@ -1,8 +1,22 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
 
 namespace Microsoft.AspNetCore.Identity.DocumentDB
 {
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum TypeEnum { User, Role }
+    public enum TypeEnum
+    {
+        [EnumMember(Value = "user")]
+        User,
+
+        [EnumMember(Value = "userMapping")]
+        UserMapping,
+
+        [EnumMember(Value = "role")]
+        Role,
+
+        [EnumMember(Value = "roleMapping")]
+        RoleMapping
+    }
 }

--- a/src/AspNetCore.Identity.DocumentDB/UserStore.cs
+++ b/src/AspNetCore.Identity.DocumentDB/UserStore.cs
@@ -50,7 +50,11 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
 
         public virtual async Task<IdentityResult> CreateAsync(TUser user, CancellationToken token)
         {
-            user.Id = Guid.NewGuid().ToString();
+            if (user.Id == null)
+            {
+                user.Id = Guid.NewGuid().ToString();
+            }
+
             var result = await _Client.CreateDocumentAsync(_Users.DocumentsLink, user);
             user.Id = result.Resource.Id;
             user.ResourceId = result.Resource.ResourceId;

--- a/test/CoreIntegrationTests/CoreIntegrationTests.csproj
+++ b/test/CoreIntegrationTests/CoreIntegrationTests.csproj
@@ -17,9 +17,9 @@
     <ProjectReference Include="..\CoreTests\CoreTests.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.1" />

--- a/test/CoreIntegrationTests/CoreIntegrationTests.csproj
+++ b/test/CoreIntegrationTests/CoreIntegrationTests.csproj
@@ -30,8 +30,8 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' OR '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.21.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />

--- a/test/CoreIntegrationTests/CoreIntegrationTests.csproj
+++ b/test/CoreIntegrationTests/CoreIntegrationTests.csproj
@@ -31,7 +31,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' OR '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />

--- a/test/CoreIntegrationTests/CoreIntegrationTests.csproj
+++ b/test/CoreIntegrationTests/CoreIntegrationTests.csproj
@@ -17,9 +17,9 @@
     <ProjectReference Include="..\CoreTests\CoreTests.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.1" />

--- a/test/CoreIntegrationTests/PartitioningTests.cs
+++ b/test/CoreIntegrationTests/PartitioningTests.cs
@@ -1,0 +1,150 @@
+﻿using IntegrationTests;
+using Microsoft.AspNetCore.Identity.DocumentDB;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CoreIntegrationTests
+{
+    public class PartitioningTests : UserIntegrationTestsBase
+    {
+        private static readonly PartitionKeyDefinition partitionKey = new PartitionKeyDefinition
+        {
+            Paths = new Collection<string> { "/partition" }
+        };
+
+        public PartitioningTests()
+            : base(partitionKey)
+        { }
+
+        [Fact]
+        public async Task User_CreateAsync_UserNameSet()
+        {
+            var userManager = GetUserManager();
+
+            // create user
+            var user1 = new IdentityUser { UserName = "user1" };
+            var user2 = new IdentityUser { UserName = "user2" };
+            await userManager.CreateAsync(user1);
+            await userManager.CreateAsync(user2);
+
+            // check query on collection
+            var results = Client.CreateDocumentQuery(Users.DocumentsLink, new FeedOptions { EnableCrossPartitionQuery = true }).ToList();
+
+            // 2 documents per user (main document & username mapping, no email mapping because none was given)
+            Assert.Equal(4, results.Count);
+
+            var dbUser1 = (IdentityUser)(dynamic)results[0];
+            Assert.Equal(user1.Id, dbUser1.Id);
+            var mappingUsername1 = (dynamic)results[1];
+            Assert.Equal(dbUser1.NormalizedUserName, mappingUsername1.Id);
+            Assert.Equal(dbUser1.Id, mappingUsername1.targetId);
+
+            var dbUser2 = (IdentityUser)(dynamic)results[2];
+            Assert.Equal(user2.Id, dbUser2.Id);
+            var mappingUsername2 = (dynamic)results[3];
+            Assert.Equal(dbUser2.NormalizedUserName, mappingUsername2.Id);
+            Assert.Equal(dbUser2.Id, mappingUsername2.targetId);
+
+            // .NET Identity Framework - get all results
+            var userList = userManager.Users.ToList();
+            Assert.Equal(2, userList.Count);
+        }
+
+        [Fact]
+        public async Task User_CreateAsync_UserNameAndEmailSet()
+        {
+            var userManager = GetUserManager();
+
+            // create user
+            var user1 = new IdentityUser { UserName = "user1", Email = "test1@test.test" };
+            var user2 = new IdentityUser { UserName = "user2", Email = "test2@test.test" };
+            await userManager.CreateAsync(user1);
+            await userManager.CreateAsync(user2);
+
+            // check query on collection
+            var results = Client.CreateDocumentQuery(Users.DocumentsLink, new FeedOptions { EnableCrossPartitionQuery = true }).ToList();
+            Assert.Equal(6, results.Count); // 2 documents per user
+
+            var dbUser1 = (IdentityUser)(dynamic)results[0];
+            Assert.Equal(user1.Id, dbUser1.Id);
+            var mappingUsername1 = (dynamic)results[1];
+            Assert.Equal(dbUser1.NormalizedUserName, mappingUsername1.Id);
+            Assert.Equal(dbUser1.Id, mappingUsername1.targetId);
+            var mappingEmail1 = (dynamic)results[2];
+            Assert.Equal(dbUser1.NormalizedEmail, mappingEmail1.Id);
+            Assert.Equal(dbUser1.Id, mappingEmail1.targetId);
+
+            var dbUser2 = (IdentityUser)(dynamic)results[3];
+            Assert.Equal(user2.Id, dbUser2.Id);
+            var mappingUsername2 = (dynamic)results[4];
+            Assert.Equal(dbUser2.NormalizedUserName, mappingUsername2.Id);
+            Assert.Equal(dbUser2.Id, mappingUsername2.targetId);
+            var mappingEmail2 = (dynamic)results[5];
+            Assert.Equal(dbUser2.NormalizedEmail, mappingEmail2.Id);
+            Assert.Equal(dbUser2.Id, mappingEmail2.targetId);
+
+            // .NET Identity Framework - get all results
+            var userList = userManager.Users.ToList();
+            Assert.Equal(2, userList.Count);
+        }
+
+        [Fact]
+        public async Task User_FindById()
+        {
+            var userManager = GetUserManager();
+
+            // create user
+            var user1 = new IdentityUser { UserName = "user1", Email = "test1@test.test" };
+            await userManager.CreateAsync(user1);
+
+            var userFound = await userManager.FindByIdAsync(user1.Id);
+
+            Assert.NotNull(userFound);
+            Assert.Equal(user1.Id, userFound.Id);
+            Assert.Equal(user1.UserName, userFound.UserName);
+            Assert.Equal(user1.Email, userFound.Email);
+        }
+
+        [Fact]
+        public async Task User_FindByName()
+        {
+            var userManager = GetUserManager();
+
+            // create user
+            var user1 = new IdentityUser { UserName = "user1", Email = "test1@test.test" };
+            await userManager.CreateAsync(user1);
+
+            var userFound = await userManager.FindByNameAsync(user1.UserName);
+
+            Assert.NotNull(userFound);
+            Assert.Equal(user1.Id, userFound.Id);
+            Assert.Equal(user1.UserName, userFound.UserName);
+            Assert.Equal(user1.Email, userFound.Email);
+        }
+
+        [Fact]
+        public async Task User_FindByEmail()
+        {
+            var userManager = GetUserManager();
+
+            // create user
+            var user1 = new IdentityUser { UserName = "user1", Email = "test1@test.test" };
+            await userManager.CreateAsync(user1);
+
+            var userFound = await userManager.FindByEmailAsync(user1.Email);
+
+            Assert.NotNull(userFound);
+            Assert.Equal(user1.Id, userFound.Id);
+            Assert.Equal(user1.UserName, userFound.UserName);
+            Assert.Equal(user1.Email, userFound.Email);
+        }
+
+    }
+}

--- a/test/CoreTests/CoreTests.csproj
+++ b/test/CoreTests/CoreTests.csproj
@@ -12,9 +12,9 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.1" />

--- a/test/CoreTests/CoreTests.csproj
+++ b/test/CoreTests/CoreTests.csproj
@@ -12,9 +12,9 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'netcoreapp1.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.1" />

--- a/test/CoreTests/CoreTests.csproj
+++ b/test/CoreTests/CoreTests.csproj
@@ -25,8 +25,8 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.0.0" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' OR '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.21.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />

--- a/test/CoreTests/CoreTests.csproj
+++ b/test/CoreTests/CoreTests.csproj
@@ -26,7 +26,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' OR '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Azure.DocumentDB" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />

--- a/test/CoreTests/DocumentDBIdentityBuilderExtensionsTests.cs
+++ b/test/CoreTests/DocumentDBIdentityBuilderExtensionsTests.cs
@@ -1,7 +1,9 @@
 ﻿using System.Security.Claims;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Options;
+using Xunit;
 
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
 namespace CoreTests
 {
     using Microsoft.AspNetCore.Identity;

--- a/test/CoreTests/DocumentDBIdentityBuilderExtensionsTests.cs
+++ b/test/CoreTests/DocumentDBIdentityBuilderExtensionsTests.cs
@@ -19,32 +19,10 @@ namespace CoreTests
     public class DocumentDBIdentityBuilderExtensionsTests
     {
         static readonly string databaseId = "AspDotNetCore.Identity.DocumentDB.Test";
+        static readonly string collectionId = "Users.Collection.Test";
         static readonly string key = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 
         DocumentClient client = new DocumentClient(new Uri("https://localhost:8081"), key);
-
-        [Fact]
-        [Trait("Category", "BreaksUnix")]
-        public void AddDocumentDBStores_WithDefaultTypes_ResolvesStoresAndManagers()
-        {
-            var services = new ServiceCollection();
-            services.AddIdentityWithDocumentDBStores(client, UriFactory.CreateDatabaseUri(databaseId).ToString());
-            // note: UserManager and RoleManager use logging
-            services.AddLogging();
-
-            var provider = services.BuildServiceProvider();
-            var resolvedUserStore = provider.GetService<IUserStore<IdentityUser>>();
-            Assert.NotNull(resolvedUserStore); // "User store did not resolve"
-
-            var resolvedRoleStore = provider.GetService<IRoleStore<IdentityRole>>();
-            Assert.NotNull(resolvedRoleStore); // "Role store did not resolve"
-
-            var resolvedUserManager = provider.GetService<UserManager<IdentityUser>>();
-            Assert.NotNull(resolvedUserManager); // "User manager did not resolve"
-
-            var resolvedRoleManager = provider.GetService<RoleManager<IdentityRole>>();
-            Assert.NotNull(resolvedRoleManager); // "Role manager did not resolve
-        }
 
         [Fact]
         [Trait("Category", "BreaksUnix")]
@@ -54,7 +32,8 @@ namespace CoreTests
             services.AddIdentityWithDocumentDBStores(options =>
             {
                 options.EnableDocumentDbEmulatorSupport();
-                options.CollectionId = databaseId;
+                options.DatabaseId = databaseId;
+                options.CollectionId = collectionId;
             });
             // note: UserManager and RoleManager use logging
             services.AddLogging();
@@ -81,7 +60,8 @@ namespace CoreTests
             services.AddIdentityWithDocumentDBStores(options =>
             {
                 options.EnableDocumentDbEmulatorSupport();
-                options.CollectionId = databaseId;
+                options.DatabaseId = databaseId;
+                options.CollectionId = collectionId;
             }, identOptions =>
             {
                 identOptions.ClaimsIdentity.UserNameClaimType = ClaimTypes.WindowsUserClaim;
@@ -107,30 +87,6 @@ namespace CoreTests
 
         [Fact]
         [Trait("Category", "BreaksUnix")]
-        public void AddDocumentDBStores_WithCustomTypes_ThisShouldLookReasonableForUsers()
-        {
-            // this test is just to make sure I consider the interface for using custom types
-            // so that it's not a horrible experience even though it should be rarely used
-            var services = new ServiceCollection();
-            services.AddIdentityWithDocumentDBStores<CustomUser, CustomRole>(client, UriFactory.CreateDatabaseUri(databaseId).ToString());
-            services.AddLogging();
-
-            var provider = services.BuildServiceProvider();
-            var resolvedUserStore = provider.GetService<IUserStore<CustomUser>>();
-            Assert.NotNull(resolvedUserStore); // "User store did not resolve"
-
-            var resolvedRoleStore = provider.GetService<IRoleStore<CustomRole>>();
-            Assert.NotNull(resolvedRoleStore); // "Role store did not resolve"
-
-            var resolvedUserManager = provider.GetService<UserManager<CustomUser>>();
-            Assert.NotNull(resolvedUserManager); // "User manager did not resolve"
-
-            var resolvedRoleManager = provider.GetService<RoleManager<CustomRole>>();
-            Assert.NotNull(resolvedRoleManager); // "Role manager did not resolve"
-        }
-
-        [Fact]
-        [Trait("Category", "BreaksUnix")]
         public void AddDocumentDBStores_WithCustomTypesViaOptions_ThisShouldLookReasonableForUsers()
         {
             // this test is just to make sure I consider the interface for using custom types
@@ -140,7 +96,8 @@ namespace CoreTests
             services.AddIdentityWithDocumentDBStores<CustomUser, CustomRole>(options =>
             {
                 options.EnableDocumentDbEmulatorSupport();
-                options.CollectionId = databaseId;
+                options.DatabaseId = databaseId;
+                options.CollectionId = collectionId;
             });
             services.AddLogging();
 
@@ -163,15 +120,19 @@ namespace CoreTests
         {
             DocumentClient client = null;
 
-            string databaseId = "fake";
+            string collectionId = "fake";
 
             var ex = Assert.Throws<ArgumentException>(() =>
             {
                 new ServiceCollection()
                 .AddIdentity<IdentityUser, IdentityRole>()
-                .RegisterDocumentDBStores<IdentityUser, IdentityRole>(client, UriFactory.CreateDatabaseUri(databaseId).ToString());
+                .RegisterDocumentDBStores<IdentityUser, IdentityRole>(options =>
+                {
+                    options.EnableDocumentDbEmulatorSupport();
+                    options.CollectionId = collectionId;
+                });
             });
-            Assert.Equal("documentClient cannot be null", ex.Message);
+            Assert.Equal("DatabaseId cannot be null.", ex.Message);
         }
 
         protected class WrongUser : IdentityUser
@@ -190,7 +151,12 @@ namespace CoreTests
             {
                 new ServiceCollection()
                     .AddIdentity<IdentityUser, IdentityRole>()
-                    .RegisterDocumentDBStores<WrongUser, IdentityRole>(client, UriFactory.CreateDatabaseUri(databaseId).ToString());
+                    .RegisterDocumentDBStores<WrongUser, IdentityRole>(options =>
+                    {
+                        options.EnableDocumentDbEmulatorSupport();
+                        options.DatabaseId = databaseId;
+                        options.CollectionId = collectionId;
+                    });
             });
             Assert.Equal("User type passed to RegisterDocumentDBStores must match user type passed to AddIdentity. You passed Microsoft.AspNetCore.Identity.DocumentDB.IdentityUser to AddIdentity and CoreTests.DocumentDBIdentityBuilderExtensionsTests+WrongUser to RegisterDocumentDBStores, these do not match.", ex.Message);
 
@@ -198,7 +164,12 @@ namespace CoreTests
             {
                 new ServiceCollection()
                     .AddIdentity<IdentityUser, IdentityRole>()
-                    .RegisterDocumentDBStores<IdentityUser, WrongRole>(client, UriFactory.CreateDatabaseUri(databaseId).ToString());
+                    .RegisterDocumentDBStores<IdentityUser, WrongRole>(options =>
+                    {
+                        options.EnableDocumentDbEmulatorSupport();
+                        options.DatabaseId = databaseId;
+                        options.CollectionId = collectionId;
+                    });
             });
             Assert.Equal("Role type passed to RegisterDocumentDBStores must match role type passed to AddIdentity. You passed Microsoft.AspNetCore.Identity.DocumentDB.IdentityRole to AddIdentity and CoreTests.DocumentDBIdentityBuilderExtensionsTests+WrongRole to RegisterDocumentDBStores, these do not match.", ex2.Message);
         }
@@ -207,23 +178,29 @@ namespace CoreTests
         [Trait("Category", "BreaksUnix")]
         public async Task AddDocumentDBStores_NewAndExistingCollections()
         {
-            var collection = client.CreateDocumentCollectionQuery(UriFactory.CreateDatabaseUri(databaseId)).Where(c => c.Id.Equals("users")).AsEnumerable().FirstOrDefault();
+            var collection = client.CreateDocumentCollectionQuery(UriFactory.CreateDatabaseUri(databaseId)).Where(c => c.Id.Equals(collectionId)).AsEnumerable().FirstOrDefault();
 
-            // when collection does not exist
             if (collection != null) { await client.DeleteDocumentCollectionAsync(collection.SelfLink); }
 
-            // does not throw:
+            // when collection does not exist does not throw:
             new ServiceCollection()
                 .AddIdentity<IdentityUser, IdentityRole>()
-                .RegisterDocumentDBStores<IdentityUser, IdentityRole>(client, UriFactory.CreateDatabaseUri(databaseId).ToString());
+                .RegisterDocumentDBStores<IdentityUser, IdentityRole>(options =>
+                {
+                    options.EnableDocumentDbEmulatorSupport();
+                    options.DatabaseId = databaseId;
+                    options.CollectionId = collectionId;
+                });
 
-            // when collection exists
-            collection = await client.CreateDocumentCollectionAsync(UriFactory.CreateDatabaseUri(databaseId), new DocumentCollection { Id = "users" });
-
-            // does not throw:
+            // when collection exists does not throw:
             new ServiceCollection()
                 .AddIdentity<IdentityUser, IdentityRole>()
-                .RegisterDocumentDBStores<IdentityUser, IdentityRole>(client, UriFactory.CreateDatabaseUri(databaseId).ToString());
+                .RegisterDocumentDBStores<IdentityUser, IdentityRole>(options =>
+                {
+                    options.EnableDocumentDbEmulatorSupport();
+                    options.DatabaseId = databaseId;
+                    options.CollectionId = collectionId;
+                });
         }
     }
 }


### PR DESCRIPTION
This is the first iteration of the partitioning support.
There are still issues e.g. with setting and querying Logins but the basic functionalities of User & Role stores should work.

There were some other refactorings and changes like all JSON properties are now camelCase.
Thus it is not compatible with datasets of older library versions.

Currently the library only supports "/partition" as the JSON field for the partition key.
There is a configuration variable for it but setting it to something other than "/partition" will fail.