### PR TITLE
merge partitioning changes

### DIFF
--- a/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
+++ b/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
@@ -9,15 +9,21 @@
     <AssemblyName>AspNetCore.Identity.DocumentDB</AssemblyName>
     <PackageId>AspNetCore.Identity.DocumentDB</PackageId>
     <PackageTags>AspNetCore;Azure;CosmosDB;DocumentDB;identity;membership</PackageTags>
-    <PackageReleaseNotes>
-        This is the first iteration of the partitioning support.
-        There are still issues e.g. with setting and querying Logins but the basic functionalities of User and Role stores should work.
+    <PackageReleaseNotes>beta1:
+This is the first iteration of the partitioning support.
+There are still issues e.g. with setting and querying Logins but the basic functionalities of User and Role stores should work.
 
-        There were some other refactorings and changes like all JSON properties are now camelCase.
-        Thus it is not compatible with datasets of older library versions.
+There were some other refactorings and changes like all JSON properties are now camelCase.
+Thus it is not compatible with datasets of older library versions.
 
-        Currently the library only supports "/partition" as the JSON field for the partition key.
-        There is a configuration variable for it but setting it to something other than "/partition" will fail.
+Currently the library only supports "/partition" as the JSON field for the partition key.
+There is a configuration variable for it but setting it to something other than "/partition" will fail.
+        
+beta2:
+The document ID and partition key now have different values.
+The C# IdentityUser "UserId" property is used as the partition key. The Id field is set to the static value "user".
+Thus when using partitioning the UserId should be passed to FindByIdAsync instead of the Id field.
+I will probably change this to avoid confusion in a future release.
     </PackageReleaseNotes>
     <PackageIconUrl>https://raw.githubusercontent.com/FelschR/AspNetCore.Identity.DocumentDB/netcore/imgs/icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/FelschR/AspNetCore.Identity.DocumentDB</PackageProjectUrl>

--- a/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
+++ b/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>A DocumentDB (Cosmos DB) provider for ASP.NET Core Identity framework.</Description>
-    <VersionPrefix>2.0.0-beta</VersionPrefix>
+    <VersionPrefix>2.0.0-beta2</VersionPrefix>
     <Authors>Felix Schröter</Authors>
     <TargetFrameworks>net451;netstandard1.6;netstandard2.0</TargetFrameworks>
     <WarningsAsErrors>true</WarningsAsErrors>

--- a/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
+++ b/src/AspNetCore.Identity.DocumentDB/AspNetCore.Identity.DocumentDB.csproj
@@ -9,21 +9,10 @@
     <AssemblyName>AspNetCore.Identity.DocumentDB</AssemblyName>
     <PackageId>AspNetCore.Identity.DocumentDB</PackageId>
     <PackageTags>AspNetCore;Azure;CosmosDB;DocumentDB;identity;membership</PackageTags>
-    <PackageReleaseNotes>beta1:
-This is the first iteration of the partitioning support.
-There are still issues e.g. with setting and querying Logins but the basic functionalities of User and Role stores should work.
+    <PackageReleaseNotes>The document IDs are now set to "user" and "role" instead of using the same value as in the partition key.
 
-There were some other refactorings and changes like all JSON properties are now camelCase.
-Thus it is not compatible with datasets of older library versions.
-
-Currently the library only supports "/partition" as the JSON field for the partition key.
-There is a configuration variable for it but setting it to something other than "/partition" will fail.
-        
-beta2:
-The document ID and partition key now have different values.
-The C# IdentityUser "UserId" property is used as the partition key. The Id field is set to the static value "user".
-Thus when using partitioning the UserId should be passed to FindByIdAsync instead of the Id field.
-I will probably change this to avoid confusion in a future release.
+The C# IdentityUser and IdentityRole classes still have a single public Id property which returns either the document ID or the partition key depending on whether the collection is partitioned.
+The API remains the same but the data model has changed and the library is thus not compatible with 2.0.0-beta datasets.
     </PackageReleaseNotes>
     <PackageIconUrl>https://raw.githubusercontent.com/FelschR/AspNetCore.Identity.DocumentDB/netcore/imgs/icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/FelschR/AspNetCore.Identity.DocumentDB</PackageProjectUrl>

--- a/src/AspNetCore.Identity.DocumentDB/Helper.cs
+++ b/src/AspNetCore.Identity.DocumentDB/Helper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
@@ -66,6 +68,17 @@ namespace AspNetCore.Identity.DocumentDB
             }
 
             return options;
+        }
+
+        public static String GetEnumMemberValue<T>(T value)
+            where T : struct, IConvertible
+        {
+            return typeof(T)
+                .GetTypeInfo()
+                .DeclaredMembers
+                .SingleOrDefault(x => x.Name == value.ToString())
+                ?.GetCustomAttribute<EnumMemberAttribute>(false)
+                ?.Value;
         }
     }
 }

--- a/src/AspNetCore.Identity.DocumentDB/IdentityRole.cs
+++ b/src/AspNetCore.Identity.DocumentDB/IdentityRole.cs
@@ -15,8 +15,15 @@
         }
 
         // TODO make the field name "partition" configurable
-        [JsonProperty("partition")]
-        public virtual string PartitionKey { get { return Id; } }
+        [JsonProperty("partition", NullValueHandling = NullValueHandling.Ignore)]
+        public virtual string RoleId { get; set; }
+
+        // TODO make configurable
+        /// <summary>
+        /// Fixed ID "role". Unique within partition.
+        /// </summary>
+        [JsonProperty(PropertyName = "id")]
+        public override string Id { get; set; }
 
         [JsonProperty(PropertyName = "type")]
         public virtual TypeEnum Type { get { return TypeEnum.Role; } }

--- a/src/AspNetCore.Identity.DocumentDB/IdentityRole.cs
+++ b/src/AspNetCore.Identity.DocumentDB/IdentityRole.cs
@@ -14,19 +14,18 @@
             Name = roleName;
         }
 
+        [JsonIgnore]
+        public override string Id { get { return RoleId ?? DocId; } set { DocId = value; } }
+
         // TODO make the field name "partition" configurable
         [JsonProperty("partition", NullValueHandling = NullValueHandling.Ignore)]
-        public virtual string RoleId { get; set; }
+        internal virtual string RoleId { get; set; }
 
-        // TODO make configurable
-        /// <summary>
-        /// Fixed ID "role". Unique within partition.
-        /// </summary>
         [JsonProperty(PropertyName = "id")]
-        public override string Id { get; set; }
+        internal string DocId { get; set; }
 
         [JsonProperty(PropertyName = "type")]
-        public virtual TypeEnum Type { get { return TypeEnum.Role; } }
+        public virtual TypeEnum Type => TypeEnum.Role;
 
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }

--- a/src/AspNetCore.Identity.DocumentDB/IdentityUser.cs
+++ b/src/AspNetCore.Identity.DocumentDB/IdentityUser.cs
@@ -14,19 +14,18 @@
             Tokens = new List<IdentityUserToken>();
         }
 
+        [JsonIgnore]
+        public override string Id { get { return UserId ?? DocId; } set { DocId = value; } }
+
         // TODO make the field name "partition" configurable
         [JsonProperty("partition", NullValueHandling = NullValueHandling.Ignore)]
-        public virtual string UserId { get; set; }
+        internal virtual string UserId { get; set; }
 
-        // TODO make configurable
-        /// <summary>
-        /// Fixed ID "user". Unique within partition.
-        /// </summary>
         [JsonProperty(PropertyName = "id")]
-        public override string Id { get; set; }
+        internal string DocId { get; set; }
 
         [JsonProperty(PropertyName = "type")]
-        public virtual TypeEnum Type { get { return TypeEnum.User; } }
+        internal virtual TypeEnum Type => TypeEnum.User;
 
         [JsonProperty(PropertyName = "userName")]
         public virtual string UserName { get; set; }

--- a/src/AspNetCore.Identity.DocumentDB/IdentityUser.cs
+++ b/src/AspNetCore.Identity.DocumentDB/IdentityUser.cs
@@ -15,8 +15,15 @@
         }
 
         // TODO make the field name "partition" configurable
-        [JsonProperty("partition")]
-        public virtual string PartitionKey { get { return Id; } }
+        [JsonProperty("partition", NullValueHandling = NullValueHandling.Ignore)]
+        public virtual string UserId { get; set; }
+
+        // TODO make configurable
+        /// <summary>
+        /// Fixed ID "user". Unique within partition.
+        /// </summary>
+        [JsonProperty(PropertyName = "id")]
+        public override string Id { get; set; }
 
         [JsonProperty(PropertyName = "type")]
         public virtual TypeEnum Type { get { return TypeEnum.User; } }

--- a/src/AspNetCore.Identity.DocumentDB/PartitionMapping.cs
+++ b/src/AspNetCore.Identity.DocumentDB/PartitionMapping.cs
@@ -18,6 +18,9 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
         [JsonProperty("id")]
         public TypeEnum Id { get; set; }
 
+        [JsonProperty("type")]
+        private TypeEnum Type => Id;
+
         [JsonProperty("targetId")]
         public string TargetId { get; set; }
     }

--- a/src/AspNetCore.Identity.DocumentDB/PartitionMapping.cs
+++ b/src/AspNetCore.Identity.DocumentDB/PartitionMapping.cs
@@ -13,10 +13,10 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
     {
         // TODO make configurable
         [JsonProperty("partition")]
-        public string PartitionKey { get { return Id; } }
+        public string PartitionKey { get; set; }
 
-        [JsonProperty("type")]
-        public TypeEnum Type { get; set; }
+        [JsonProperty("id")]
+        public TypeEnum Id { get; set; }
 
         [JsonProperty("targetId")]
         public string TargetId { get; set; }

--- a/src/AspNetCore.Identity.DocumentDB/UserStore.cs
+++ b/src/AspNetCore.Identity.DocumentDB/UserStore.cs
@@ -50,19 +50,22 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
 
         public virtual async Task<IdentityResult> CreateAsync(TUser user, CancellationToken token)
         {
-            if (user.Id == null)
+            if (UsesPartitioning)
             {
-                user.Id = Guid.NewGuid().ToString();
+                user.Id = "user";
+                user.UserId = Guid.NewGuid().ToString();
             }
 
             var result = await _Client.CreateDocumentAsync(_Users.DocumentsLink, user);
-            user.Id = result.Resource.Id;
-            user.ResourceId = result.Resource.ResourceId;
+            var userResult = (TUser)(dynamic)result.Resource;
+            user.Id = userResult.Id;
+            user.UserId = userResult.UserId;
+            user.ResourceId = userResult.ResourceId;
 
             if (UsesPartitioning)
             {
-                await CreateMapping(user.NormalizedUserName, user.Id);
-                await CreateMapping(user.NormalizedEmail, user.Id);
+                await CreateMapping(user.NormalizedUserName, user.UserId);
+                await CreateMapping(user.NormalizedEmail, user.UserId);
             }
 
             return IdentityResult.Success;
@@ -70,20 +73,20 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
 
         public virtual async Task<IdentityResult> UpdateAsync(TUser user, CancellationToken token)
         {
-            var oldUser = await FindByIdAsync(user.Id, token);
+            var oldUser = await FindByIdAsync(user.UserId, token);
 
             if (UsesPartitioning)
             {
                 if (oldUser.NormalizedUserName != user.NormalizedUserName)
                 {
                     await DeleteMapping(oldUser.NormalizedUserName);
-                    await CreateMapping(user.NormalizedUserName, user.Id);
+                    await CreateMapping(user.NormalizedUserName, user.UserId);
                 }
 
                 if (oldUser.NormalizedEmail != user.NormalizedEmail)
                 {
                     await DeleteMapping(oldUser.NormalizedEmail);
-                    await CreateMapping(user.NormalizedEmail, user.Id);
+                    await CreateMapping(user.NormalizedEmail, user.UserId);
                 }
             }
 
@@ -105,7 +108,7 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
                     return DeleteMapping(partitionKey);
                 }));*/
             }
-            await _Client.DeleteDocumentAsync(GetUserUri(user), GetRequestOptions(user.PartitionKey));
+            await _Client.DeleteDocumentAsync(GetUserUri(user), GetRequestOptions(user.UserId));
 
             // todo success based on delete result
             return IdentityResult.Success;
@@ -128,18 +131,27 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
             => user.NormalizedUserName = normalizedUserName;
 
         public virtual async Task<TUser> FindByIdAsync(string userId, CancellationToken token)
-            => _Client.CreateDocumentQuery<TUser>(_Users.DocumentsLink, GetFeedOptions(userId)).Where(u => u.Id == userId).AsEnumerable().FirstOrDefault();
+        {
+            if (UsesPartitioning)
+            {
+                return _Client.CreateDocumentQuery<TUser>(_Users.DocumentsLink, GetFeedOptions(userId))
+                    .Where(u => u.Id == "user").AsEnumerable().FirstOrDefault();
+            }
+
+            return _Client.CreateDocumentQuery<TUser>(_Users.DocumentsLink)
+                .Where(u => u.Type == TypeEnum.User && u.Id == userId).AsEnumerable().FirstOrDefault();
+        }
 
         public virtual async Task<TUser> FindByNameAsync(string normalizedUserName, CancellationToken token)
         {
             if (UsesPartitioning)
             {
                 var partitionKeyMapping = _Client.CreateDocumentQuery<PartitionMapping>(_Users.DocumentsLink, GetFeedOptions(normalizedUserName))
-                    .Where(u => u.Type == TypeEnum.UserMapping && u.Id == normalizedUserName).AsEnumerable().FirstOrDefault();
+                    .Where(u => u.Id == TypeEnum.UserMapping).AsEnumerable().FirstOrDefault();
 
                 return partitionKeyMapping != null ?
                     _Client.CreateDocumentQuery<TUser>(_Users.DocumentsLink, GetFeedOptions(partitionKeyMapping.TargetId))
-                    .Where(u => u.Type == TypeEnum.User && u.NormalizedUserName == normalizedUserName).AsEnumerable().FirstOrDefault() : null;
+                    .Where(u => u.Type == TypeEnum.User && u.Id == "user").AsEnumerable().FirstOrDefault() : null;
             }
 
             return _Client.CreateDocumentQuery<TUser>(_Users.DocumentsLink)
@@ -251,11 +263,11 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
             if (UsesPartitioning)
             {
                 var partitionKeyMapping = _Client.CreateDocumentQuery<PartitionMapping>(_Users.DocumentsLink, GetFeedOptions(normalizedEmail))
-                    .Where(u => u.Type == TypeEnum.UserMapping && u.Id == normalizedEmail).AsEnumerable().FirstOrDefault();
+                    .Where(u => u.Id == TypeEnum.UserMapping).AsEnumerable().FirstOrDefault();
 
                 return partitionKeyMapping != null ?
                     _Client.CreateDocumentQuery<TUser>(_Users.DocumentsLink, GetFeedOptions(partitionKeyMapping.TargetId))
-                    .Where(u => u.Type == TypeEnum.User && u.NormalizedEmail == normalizedEmail).AsEnumerable().FirstOrDefault() : null;
+                    .Where(u => u.Type == TypeEnum.User && u.Id == "user").AsEnumerable().FirstOrDefault() : null;
             }
 
             return _Client.CreateDocumentQuery<TUser>(_Users.DocumentsLink)
@@ -401,8 +413,8 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
 
             await _Client.CreateDocumentAsync(_Users.DocumentsLink, new PartitionMapping
             {
-                Id = id,
-                Type = TypeEnum.UserMapping,
+                PartitionKey = id,
+                Id = TypeEnum.UserMapping,
                 TargetId = targetId
             });
         }
@@ -411,7 +423,8 @@ namespace Microsoft.AspNetCore.Identity.DocumentDB
         {
             if (id != null)
             {
-                await _Client.DeleteDocumentAsync(GetUserUri(id), GetRequestOptions(id));
+                var typeString = Helper.GetEnumMemberValue(TypeEnum.UserMapping);
+                await _Client.DeleteDocumentAsync(GetUserUri(typeString), GetRequestOptions(id));
             }
         }
 

--- a/test/CoreIntegrationTests/PartitioningTests.cs
+++ b/test/CoreIntegrationTests/PartitioningTests.cs
@@ -50,14 +50,14 @@ namespace CoreIntegrationTests
             var mappingUsername1 = (dynamic)results[1];
             Assert.Equal(userMappingStr, mappingUsername1.Id);
             Assert.Equal(dbUser1.NormalizedUserName, mappingUsername1.partition);
-            Assert.Equal(dbUser1.UserId, mappingUsername1.targetId);
+            Assert.Equal(dbUser1.Id, mappingUsername1.targetId);
 
             var dbUser2 = (IdentityUser)(dynamic)results[2];
             Assert.Equal(user2.Id, dbUser2.Id);
             var mappingUsername2 = (dynamic)results[3];
             Assert.Equal(userMappingStr, mappingUsername2.Id);
             Assert.Equal(dbUser2.NormalizedUserName, mappingUsername2.partition);
-            Assert.Equal(dbUser2.UserId, mappingUsername2.targetId);
+            Assert.Equal(dbUser2.Id, mappingUsername2.targetId);
 
             // .NET Identity Framework - get all results
             var userList = userManager.Users.ToList();
@@ -84,22 +84,22 @@ namespace CoreIntegrationTests
             var mappingUsername1 = (dynamic)results[1];
             Assert.Equal(userMappingStr, mappingUsername1.Id);
             Assert.Equal(dbUser1.NormalizedUserName, mappingUsername1.partition);
-            Assert.Equal(dbUser1.UserId, mappingUsername1.targetId);
+            Assert.Equal(dbUser1.Id, mappingUsername1.targetId);
             var mappingEmail1 = (dynamic)results[2];
             Assert.Equal(userMappingStr, mappingEmail1.Id);
             Assert.Equal(dbUser1.NormalizedEmail, mappingEmail1.partition);
-            Assert.Equal(dbUser1.UserId, mappingEmail1.targetId);
+            Assert.Equal(dbUser1.Id, mappingEmail1.targetId);
 
             var dbUser2 = (IdentityUser)(dynamic)results[3];
             Assert.Equal(user2.Id, dbUser2.Id);
             var mappingUsername2 = (dynamic)results[4];
             Assert.Equal(userMappingStr, mappingUsername2.Id);
             Assert.Equal(dbUser2.NormalizedUserName, mappingUsername2.partition);
-            Assert.Equal(dbUser2.UserId, mappingUsername2.targetId);
+            Assert.Equal(dbUser2.Id, mappingUsername2.targetId);
             var mappingEmail2 = (dynamic)results[5];
             Assert.Equal(userMappingStr, mappingEmail2.Id);
             Assert.Equal(dbUser2.NormalizedEmail, mappingEmail2.partition);
-            Assert.Equal(dbUser2.UserId, mappingEmail2.targetId);
+            Assert.Equal(dbUser2.Id, mappingEmail2.targetId);
 
             // .NET Identity Framework - get all results
             var userList = userManager.Users.ToList();
@@ -115,11 +115,10 @@ namespace CoreIntegrationTests
             var user1 = new IdentityUser { UserName = "user1", Email = "test1@test.test" };
             await userManager.CreateAsync(user1);
 
-            var userFound = await userManager.FindByIdAsync(user1.UserId);
+            var userFound = await userManager.FindByIdAsync(user1.Id);
 
             Assert.NotNull(userFound);
             Assert.Equal(user1.Id, userFound.Id);
-            Assert.Equal(user1.UserId, userFound.UserId);
             Assert.Equal(user1.UserName, userFound.UserName);
             Assert.Equal(user1.Email, userFound.Email);
         }

--- a/test/CoreIntegrationTests/PartitioningTests.cs
+++ b/test/CoreIntegrationTests/PartitioningTests.cs
@@ -1,4 +1,5 @@
-﻿using IntegrationTests;
+﻿using AspNetCore.Identity.DocumentDB;
+using IntegrationTests;
 using Microsoft.AspNetCore.Identity.DocumentDB;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
@@ -18,6 +19,10 @@ namespace CoreIntegrationTests
         {
             Paths = new Collection<string> { "/partition" }
         };
+
+        private readonly string userMappingStr = Helper.GetEnumMemberValue(TypeEnum.UserMapping);
+
+        private readonly string roleMappingStr = Helper.GetEnumMemberValue(TypeEnum.RoleMapping);
 
         public PartitioningTests()
             : base(partitionKey)
@@ -43,14 +48,16 @@ namespace CoreIntegrationTests
             var dbUser1 = (IdentityUser)(dynamic)results[0];
             Assert.Equal(user1.Id, dbUser1.Id);
             var mappingUsername1 = (dynamic)results[1];
-            Assert.Equal(dbUser1.NormalizedUserName, mappingUsername1.Id);
-            Assert.Equal(dbUser1.Id, mappingUsername1.targetId);
+            Assert.Equal(userMappingStr, mappingUsername1.Id);
+            Assert.Equal(dbUser1.NormalizedUserName, mappingUsername1.partition);
+            Assert.Equal(dbUser1.UserId, mappingUsername1.targetId);
 
             var dbUser2 = (IdentityUser)(dynamic)results[2];
             Assert.Equal(user2.Id, dbUser2.Id);
             var mappingUsername2 = (dynamic)results[3];
-            Assert.Equal(dbUser2.NormalizedUserName, mappingUsername2.Id);
-            Assert.Equal(dbUser2.Id, mappingUsername2.targetId);
+            Assert.Equal(userMappingStr, mappingUsername2.Id);
+            Assert.Equal(dbUser2.NormalizedUserName, mappingUsername2.partition);
+            Assert.Equal(dbUser2.UserId, mappingUsername2.targetId);
 
             // .NET Identity Framework - get all results
             var userList = userManager.Users.ToList();
@@ -75,20 +82,24 @@ namespace CoreIntegrationTests
             var dbUser1 = (IdentityUser)(dynamic)results[0];
             Assert.Equal(user1.Id, dbUser1.Id);
             var mappingUsername1 = (dynamic)results[1];
-            Assert.Equal(dbUser1.NormalizedUserName, mappingUsername1.Id);
-            Assert.Equal(dbUser1.Id, mappingUsername1.targetId);
+            Assert.Equal(userMappingStr, mappingUsername1.Id);
+            Assert.Equal(dbUser1.NormalizedUserName, mappingUsername1.partition);
+            Assert.Equal(dbUser1.UserId, mappingUsername1.targetId);
             var mappingEmail1 = (dynamic)results[2];
-            Assert.Equal(dbUser1.NormalizedEmail, mappingEmail1.Id);
-            Assert.Equal(dbUser1.Id, mappingEmail1.targetId);
+            Assert.Equal(userMappingStr, mappingEmail1.Id);
+            Assert.Equal(dbUser1.NormalizedEmail, mappingEmail1.partition);
+            Assert.Equal(dbUser1.UserId, mappingEmail1.targetId);
 
             var dbUser2 = (IdentityUser)(dynamic)results[3];
             Assert.Equal(user2.Id, dbUser2.Id);
             var mappingUsername2 = (dynamic)results[4];
-            Assert.Equal(dbUser2.NormalizedUserName, mappingUsername2.Id);
-            Assert.Equal(dbUser2.Id, mappingUsername2.targetId);
+            Assert.Equal(userMappingStr, mappingUsername2.Id);
+            Assert.Equal(dbUser2.NormalizedUserName, mappingUsername2.partition);
+            Assert.Equal(dbUser2.UserId, mappingUsername2.targetId);
             var mappingEmail2 = (dynamic)results[5];
-            Assert.Equal(dbUser2.NormalizedEmail, mappingEmail2.Id);
-            Assert.Equal(dbUser2.Id, mappingEmail2.targetId);
+            Assert.Equal(userMappingStr, mappingEmail2.Id);
+            Assert.Equal(dbUser2.NormalizedEmail, mappingEmail2.partition);
+            Assert.Equal(dbUser2.UserId, mappingEmail2.targetId);
 
             // .NET Identity Framework - get all results
             var userList = userManager.Users.ToList();
@@ -104,10 +115,11 @@ namespace CoreIntegrationTests
             var user1 = new IdentityUser { UserName = "user1", Email = "test1@test.test" };
             await userManager.CreateAsync(user1);
 
-            var userFound = await userManager.FindByIdAsync(user1.Id);
+            var userFound = await userManager.FindByIdAsync(user1.UserId);
 
             Assert.NotNull(userFound);
             Assert.Equal(user1.Id, userFound.Id);
+            Assert.Equal(user1.UserId, userFound.UserId);
             Assert.Equal(user1.UserName, userFound.UserName);
             Assert.Equal(user1.Email, userFound.Email);
         }

--- a/test/CoreIntegrationTests/UserIntegrationTestsBase.cs
+++ b/test/CoreIntegrationTests/UserIntegrationTestsBase.cs
@@ -72,7 +72,7 @@ namespace IntegrationTests
                 collection.PartitionKey = partitionKey;
             }
 
-            Users = Client.CreateDocumentCollectionAsync(Database.SelfLink, collection).Result;
+            Users = await Client.CreateDocumentCollectionAsync(Database.SelfLink, collection);
             Roles = Users;
 
             ServiceProvider = CreateServiceProvider<IdentityUser, IdentityRole>();


### PR DESCRIPTION
The document IDs are now set to "user" and "role" instead of using the same value as in the partition key.